### PR TITLE
add kamailio healthcheck based on Diameter connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Why another setup:
 
 ## Specifications
 - SIP [RFC 3261](https://www.rfc-editor.org/rfc/rfc3261.html)
-- SDP [RFC 2327](https://www.rfc-editor.org/rfc/rfc2327.html)
+- SDP [RFC 8866](https://www.rfc-editor.org/rfc/rfc8866.html)
 - RTP [RFC 1889](https://www.rfc-editor.org/rfc/rfc1889.html)
 - IMS
   - [TS 23.228](https://www.etsi.org/deliver/etsi_ts/123200_123299/123228/18.07.00_60/ts_123228v180700p.pdf)

--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,11 @@ x-kamailio: &kamailio
   - 5060/tcp
   - 5060/udp
   dns: ${DNSIP}
+  healthcheck:
+    test: wget -qO- 127.0.0.1:9090/check
+    retries: 60 
+    interval: 1s
+    start_period: 1s
 
 services:
   pcscf:
@@ -156,6 +161,11 @@ services:
     - NET_ADMIN
     deploy:
       replicas: ${SCALE}
+    depends_on:
+      icscf:
+        condition: service_healthy
+      scscf:
+        condition: service_healthy
     build:
       context: .
       dockerfile_inline: |
@@ -186,6 +196,7 @@ services:
 configs:
   monitor.cfg:
     content: |
+      listen=0.0.0.0:9090
       http_reply_parse=yes
       tcp_accept_no_cl=yes
       loadmodule "xhttp.so"
@@ -194,8 +205,10 @@ configs:
       event_route[xhttp:request] {
       	if(prom_check_uri())
       		prom_dispatch();
+      	else if(cdp_has_app("16777216" ))
+      		xhttp_reply("200", "OK", "text/plain", "ready to serve");
       	else
-      		xhttp_reply("200", "OK", "text/html", "<html><body>Wrong URL $$hu</body></html>");
+      		xhttp_reply("500", "KO", "text/plain", "try again later");
       }
 
   pcscf.cfg:

--- a/cscf/proxy.cfg
+++ b/cscf/proxy.cfg
@@ -17,6 +17,8 @@ loadmodule "tm"
 loadmodule "pv"
 loadmodule "sl"
 loadmodule "rr"
+loadmodule "cdp"
+loadmodule "cdp_avp"
 loadmodule "textops"
 loadmodule "ims_usrloc_pcscf"
 loadmodule "ims_ipsec_pcscf"
@@ -29,6 +31,8 @@ import_file "monitor.cfg"
 
 modparam("debugger", "cfgtrace", 1)
 modparam("debugger", "log_level", 3) # L_DBG
+
+modparam("cdp", "config_file", "/etc/ims/diameter.xml")
 
 modparam("ims_ipsec_pcscf", "ipsec_listen_addr", IPSEC)
 

--- a/monitor.yml
+++ b/monitor.yml
@@ -123,14 +123,14 @@ configs:
         honor_timestamps: false
         static_configs:
         - targets:
-          - pcscf:5060
+          - pcscf:9090
       - job_name: icscf
         honor_timestamps: false
         static_configs:
         - targets:
-          - icscf:5060
+          - icscf:9090
       - job_name: scscf
         honor_timestamps: false
         static_configs:
         - targets:
-          - scscf:5060
+          - scscf:9090

--- a/test.py
+++ b/test.py
@@ -112,13 +112,12 @@ if __name__ == "__main__":
     import subprocess
     idx = int(subprocess.check_output("host $(hostname -i) | grep -o 'ims-test-\([0-9]\+\)' | cut -d - -f 3", shell=True).decode("utf-8").strip())
     run = gen(cscf=os.environ["PCSCF"], domain=os.environ["REALM"], ipsec=os.environ["IPSEC"])
-    time.sleep(50+idx*3)
     s0 = run(imsi = f'{os.environ["PLMN"]}{idx:010}',
              msisdn = f'{os.environ["DIAL"]}{idx:09}',
              Ki = os.environ["K"],
              opc = os.environ["OPC"])
 
-    time.sleep(10)
+    time.sleep(6)
 
     if idx % 2 == 0:
         #s0.removeHeader("Event")


### PR DESCRIPTION
if the 5060 port is reused for Prometheus monitoring, Wireshark interpret the traffic ad SIP which is not correct. The solution: use separate port for Prometheus monitoring